### PR TITLE
Don't use newest fork rules if server sends an earlier version

### DIFF
--- a/src/SendFunds/Controllers/SendFundsFormSubmissionController.cpp
+++ b/src/SendFunds/Controllers/SendFundsFormSubmissionController.cpp
@@ -292,6 +292,7 @@ void FormSubmissionController::cb_I__got_unspent_outs(optional<string> err_msg, 
 	this->unspent_outs = std::move(*(parsed_res.unspent_outs));
 	this->fee_per_b = *(parsed_res.per_byte_fee);
 	this->fee_mask = *(parsed_res.fee_mask);
+	this->use_fork_rules = monero_fork_rules::make_use_fork_rules_fn(parsed_res.fork_version);
 	//
 	this->passedIn_attemptAt_fee = boost::none;
 	this->constructionAttempt = 0;
@@ -310,10 +311,7 @@ void FormSubmissionController::_reenterable_construct_and_send_tx()
 		this->sending_amount,
 		this->parameters.is_sweeping,
 		this->parameters.priority,
-		[] (uint8_t version, int64_t early_blocks) -> bool
-		{
-			return lightwallet_hardcoded__use_fork_rules(version, early_blocks);
-		},
+		this->use_fork_rules,
 		this->unspent_outs,
 		this->fee_per_b,
 		this->fee_mask,
@@ -372,10 +370,7 @@ void FormSubmissionController::cb_II__got_random_outs(
 		this->fee_per_b,
 		this->fee_mask,
 		*(parsed_res.mix_outs),
-		[] (uint8_t version, int64_t early_blocks) -> bool
-		{
-		return lightwallet_hardcoded__use_fork_rules(version, early_blocks);
-		},
+		this->use_fork_rules,
 		unlock_time,
 		this->parameters.nettype
 	);

--- a/src/SendFunds/Controllers/SendFundsFormSubmissionController.hpp
+++ b/src/SendFunds/Controllers/SendFundsFormSubmissionController.hpp
@@ -41,7 +41,7 @@
 #include <boost/locale.hpp>
 #include "cryptonote_config.h"
 #include "monero_send_routine.hpp"
-
+#include "monero_fork_rules.hpp"
 
 namespace SendFunds
 {
@@ -210,6 +210,7 @@ namespace SendFunds
 		vector<SpendableOutput> unspent_outs;
 		uint64_t fee_per_b;
 		uint64_t fee_mask;
+		monero_fork_rules::use_fork_rules_fn_type use_fork_rules;
 		// - re-entry params
 		optional<uint64_t> passedIn_attemptAt_fee;
 		size_t constructionAttempt;


### PR DESCRIPTION
This requires https://github.com/mymonero/mymonero-core-cpp/pull/27/commits/d9aa140687cfa6f18ed3d095e340cc579f23d121 in the submodule `src/mymonero-core-cpp`